### PR TITLE
small updates 

### DIFF
--- a/extension/just-save.js
+++ b/extension/just-save.js
@@ -2,9 +2,26 @@
 
 let isChrome = window.browser === undefined;
 
+// Detect if running as an event page in Firefox.
+const detectFirefoxEventPageMode = () => {
+  if (isChrome) { return; }
+  try {
+    browser.contextMenus.create({ id: "test-menu", onclick: () => {} });
+  } catch (err) {
+    if (err?.message.includes("Property \"onclick\" cannot be used in menus.create")) {
+      // Set isChrome to true if Firefox is detected to be running with event pages support enabled.
+      isChrome = true;
+    }
+  } finally {
+    browser.contextMenus.remove("test-menu");
+  }
+}
+
 // adding browser shim for chrome support
 if (isChrome) {
   window.browser = chrome;
+} else {
+  detectFirefoxEventPageMode()
 }
 
 const logResult = result => {

--- a/extension/just-save.js
+++ b/extension/just-save.js
@@ -25,14 +25,14 @@ if (isChrome) {
 }
 
 const logResult = result => {
-  if (browser.extension.lastError) {
+  if (browser.runtime.lastError) {
     return;
     // debugging to console is not allowed for production extensions according to
     // preliminary review for firefox: 
     // Please note the following for the next update:
     // 1) Your add-on prints debugging information to the Console, which is generally not allowed in production add-ons.
 
-    // return console.error(browser.extension.lastError);
+    // return console.error(browser.runtime.lastError);
   }
   
   // return console.log(result);

--- a/extension/just-save.js
+++ b/extension/just-save.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let isChrome = window.browser === undefined;
+let isChrome = self.browser === undefined;
 
 // Detect if running as an event page in Firefox.
 const detectFirefoxEventPageMode = () => {
@@ -19,7 +19,7 @@ const detectFirefoxEventPageMode = () => {
 
 // adding browser shim for chrome support
 if (isChrome) {
-  window.browser = chrome;
+  self.browser = chrome;
 } else {
   detectFirefoxEventPageMode()
 }


### PR DESCRIPTION
this is a small PR containing: 
- the fix posted in https://github.com/lewisl9029/just-save-webextension/issues/10
- uses the `browser.runtme` alias instead of `browser.extension` (futureproofing for manifest v3)
- and uses the `self` global onject instead of `window` (futureproofing for manifest v3)